### PR TITLE
changed package name from Clusters to clusters for import purposes

### DIFF
--- a/clusters/shear.py
+++ b/clusters/shear.py
@@ -63,8 +63,8 @@ def compare_shear(catalogs, xclust, yclust, qcut=None, param='Tshear'):
     """Compare shear mesured on the coadd and shear measured on indivial ccd.
 
     For now, do:
-    from Clusters import data
-    from Clusters import shear
+    from clusters import data
+    from clusters import shear
     config = data.load_config('MACSJ2243.3-0935.yaml')
     catalogs = data.read_hdf5('test_data2.hdf5')
     xc, yc = shear.xy_clust(config, data.load_wcs(catalogs['wcs']))

--- a/docs/source/data_tuto.ipynb
+++ b/docs/source/data_tuto.ipynb
@@ -37,7 +37,7 @@
    },
    "outputs": [],
    "source": [
-    "from Clusters import data\n",
+    "from clusters import data\n",
     "f = \"/sps/lsst/data/clusters/MACSJ2243.3-0935/analysis/output_v1/MACSJ2243.3-0935_data.hdf5\"\n",
     "d = data.read_hdf5(f)\n",
     "fc = d['deepCoadd_forced_src']"

--- a/scripts/clusters_data.py
+++ b/scripts/clusters_data.py
@@ -2,6 +2,6 @@
 """Load the cluster data."""
 
 import sys
-from Clusters import main
+from clusters import main
 
 sys.exit(main.load_data())

--- a/scripts/clusters_extinction.py
+++ b/scripts/clusters_extinction.py
@@ -2,6 +2,6 @@
 """Load the color excess."""
 
 import sys
-from Clusters import main
+from clusters import main
 
 sys.exit(main.extinction())

--- a/scripts/clusters_getbackground.py
+++ b/scripts/clusters_getbackground.py
@@ -2,6 +2,6 @@
 """Get a cluster background galaxies."""
 
 import sys
-from Clusters import main
+from clusters import main
 
 sys.exit(main.getbackground())

--- a/scripts/clusters_pipeline.py
+++ b/scripts/clusters_pipeline.py
@@ -2,6 +2,6 @@
 """Pipeline for standard cluster analysis."""
 
 import sys
-from Clusters import main
+from clusters import main
 
 sys.exit(main.pipeline())

--- a/scripts/clusters_shear.py
+++ b/scripts/clusters_shear.py
@@ -2,6 +2,6 @@
 """Shear analysis."""
 
 import sys
-from Clusters import main
+from clusters import main
 
 sys.exit(main.shear())

--- a/scripts/clusters_zphot.py
+++ b/scripts/clusters_zphot.py
@@ -2,6 +2,6 @@
 """Comput photometric redshift using LEPHARE."""
 
 import sys
-from Clusters import main
+from clusters import main
 
 sys.exit(main.photometric_redshift())

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 import glob
 import yaml
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 README = '/'.join(os.path.realpath(__file__).split('/')[:-1]) + '/README.rst'
@@ -19,7 +19,7 @@ __version__ = yaml.load(open(VERSION))['version']
 name = 'Clusters'
 
 # Packages (subdirectories in clusters/)
-packages = ["Clusters"]
+packages = find_packages()
 
 # Scripts (in scripts/)
 scripts = glob.glob("scripts/*.py")
@@ -35,7 +35,6 @@ setup(name=name,
       url="https://github.com/nicolaschotard/Clusters",
       author="Nicolas Chotard, Dominique Boutigny, Celine Combet",
       author_email="nchotard@in2p3.fr",
-      package_dir={name: 'clusters'},
       packages=packages,
       scripts=scripts,
       package_data=package_data,

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -1,8 +1,8 @@
 """Test the reddening module."""
 
 import os
-from Clusters import main
-from Clusters import data
+from clusters import main
+from clusters import data
 
 
 CONFIG = "testdata/travis_test.yaml"
@@ -16,7 +16,7 @@ def test_load_config():
 
 
 def test_catalogs_class(config=CONFIG, datafile=DATAFILE):
-    """Test the Clusters.data.Catalogs class."""
+    """Test the clusters.data.Catalogs class."""
     if not os.path.exists('testdata'):
         get_testdata = """
         - wget https://lapp-owncloud.in2p3.fr/index.php/s/xG2AoS2jggbmP0k/download


### PR DESCRIPTION
Reverted setup.py to autodetect packages within the Clusters distribution. That means all scripts that wants to use files need to do, eg

from clusters import data

instead of 

from Clusters import data.

Note that 

for files in the clusters subdirectory,

from . import data

still works fine.